### PR TITLE
Removed an "extra" `\begin{lstlisting}`

### DIFF
--- a/Subprograms.tex
+++ b/Subprograms.tex
@@ -20,7 +20,6 @@ number.
   xleftmargin=0in,
   caption={Prime Checking Program, Version 2},
   label=lst:prime-program2]
-\begin{lstlisting}
 with Ada.Text_IO;         use Ada.Text_IO;
 with Ada.Integer_Text_IO; use Ada.Integer_Text_IO;
 


### PR DESCRIPTION
Have you considered **referencing** the source files from the LaTeX files, instead of inlining them?  It makes it easier to validate that the sources shown in the document are compilable.