### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ varying levels of depth. As with most things on GitHub, it is a work in progress
 
 You can download snapshots of this tutorial below.
 
-+ A [PDF of the tutorial](http://web.vtc.edu/users/pcc09070/TutorialAda/AdaCrash.pdf) itself.
-+ A zip archive of the [source code of the samples](http://web.vtc.edu/users/pcc09070/TutorialAda/samples.zip).
++ A [PDF of the tutorial](http://www.pchapin.org/VTC/TutorialAda/AdaCrash.pdf) itself.
++ A zip archive of the [source code of the samples](http://www.pchapin.org/VTC/TutorialAda/samples.zip).
 
 Pull requests against this repository are also welcome.
 


### PR DESCRIPTION
Links in the README file were broken. They have been updated with new
links to http://www.pchapin.org/VTC/.

Fixes #1